### PR TITLE
[feat/main to dev] 3개 탭 통합 ViewModel 정의와 동시에 History 목록 매핑 테스트

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustPan"
             android:theme="@style/Theme.Main">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
@@ -9,11 +9,18 @@ class AccountBookRepository @Inject constructor(
     private val dataSource: AccountBookDataSource
 ) {
 
-    fun getMonthlyHistories(year: Int, month: Int): Result<List<History>> {
-        return runCatching {
-            dataSource.getAllHistory(year, month)
-        }
-    }
+    fun getMonthlyHistories(year: Int, month: Int): Result<Map<String, List<History>>>
+        = runCatching { dataSource.getAllHistory(year, month) }
+
+    fun insertHistory(
+        type: Int,
+        content: String? = null,
+        date: String,
+        amount: Int,
+        paymentId: Long? = null,
+        categoryId: Long? = null
+    ): Result<Long>
+        = runCatching { dataSource.addHistory(type, content, date, amount, paymentId, categoryId) }
 
     fun getAllPaymentMethod(): Result<List<PaymentMethod>>
         = runCatching { dataSource.getAllPaymentMethod() }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/model/History.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/model/History.kt
@@ -3,9 +3,9 @@ package com.woowacamp.android_accountbook_15.data.model
 data class History(
     val id: Long,
     val type: Int,
-    val content: String,
+    val content: String? = null,
     val date: String,
     val amount: Int,
-    val payment: PaymentMethod,
-    val category: Category
+    val payment: PaymentMethod? = null,
+    val category: Category? = null
 )

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/utils/SQLConfig.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/utils/SQLConfig.kt
@@ -15,10 +15,10 @@ const val SQL_FOREIGN_SET =
 const val SQL_CREATE_HISTORY =
     "CREATE TABLE ${HistoryColumns.TABLE_NAME} (" +
             "${BaseColumns._ID} INTEGER PRIMARY KEY," +
-            "${HistoryColumns.COLUMN_NAME_TYPE} INTEGER," +
+            "${HistoryColumns.COLUMN_NAME_TYPE} INTEGER NOT NULL," +
             "${HistoryColumns.COLUMN_NAME_CONTENT} TEXT," +
-            "${HistoryColumns.COLUMN_NAME_DATE} DATETIME," +
-            "${HistoryColumns.COLUMN_NAME_AMOUNT} INTEGER," +
+            "${HistoryColumns.COLUMN_NAME_DATE} TEXT NOT NULL," +
+            "${HistoryColumns.COLUMN_NAME_AMOUNT} INTEGER NOT NULL," +
             "${HistoryColumns.COLUMN_NAME_PAYMENT_ID} INTEGER," +
             "${HistoryColumns.COLUMN_NAME_CATEGORY_ID} INTEGER," +
             "FOREIGN KEY(${HistoryColumns.COLUMN_NAME_PAYMENT_ID})" +
@@ -36,7 +36,7 @@ const val SQL_CREATE_CATEGORY =
             "${BaseColumns._ID} INTEGER PRIMARY KEY," +
             "${CategoryColumns.COLUMN_NAME_TYPE} INTEGER," +
             "${CategoryColumns.COLUMN_NAME_NAME} TEXT UNIQUE," +
-            "${CategoryColumns.COLUMN_NAME_COLOR} INTEGER UNIQUE)"
+            "${CategoryColumns.COLUMN_NAME_COLOR} INTEGER)"
 
 /**
  * Drop Table
@@ -65,4 +65,5 @@ const val SQL_SELECT_ALL_HISTORY =
     " LEFT JOIN ${PaymentMethodColumns.TABLE_NAME}" +
             " ON ${HistoryColumns.TABLE_NAME}.${BaseColumns._ID} = ${PaymentMethodColumns.TABLE_NAME}.${BaseColumns._ID}" +
     " LEFT JOIN ${CategoryColumns.TABLE_NAME}" +
-            " ON ${HistoryColumns.TABLE_NAME}.${BaseColumns._ID} = ${CategoryColumns.TABLE_NAME}.${BaseColumns._ID}"
+            " ON ${HistoryColumns.TABLE_NAME}.${BaseColumns._ID} = ${CategoryColumns.TABLE_NAME}.${BaseColumns._ID}" +
+    " WHERE substr(${HistoryColumns.COLUMN_NAME_DATE}, 1, 7) = ?" // 2001-01-30 이면 2001-01 까지 가져온다.

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/HistoryScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/HistoryScreen.kt
@@ -29,8 +29,8 @@ fun HistoryScreen(
         }
     } else {
         HistoryScreen(
-            title = getTodayMonthAndYear(year, month),
-            histories = viewModel.histories.collectAsState().value,
+            title = "${year}년 ${month}월",
+            histories = viewModel.monthlyHistories.collectAsState().value,
             onChangeModifyState = { setModifyState(true) },
             onClickLeft = {
                 setYear(if (month-1 > 0) year else year-1)
@@ -47,7 +47,7 @@ fun HistoryScreen(
 @Composable
 private fun HistoryScreen(
     title: String,
-    histories: List<History>,
+    histories: Map<String, List<History>>,
     onChangeModifyState: () -> Unit,
     onClickLeft: () -> Unit,
     onClickRight: () -> Unit

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/HistoryViewModel.kt
@@ -15,8 +15,14 @@ class HistoryViewModel @Inject constructor(
     private val repository: AccountBookRepository
 ): ViewModel() {
 
-    private val _histories = MutableStateFlow(
-        repository.getMonthlyHistories(getTodayYear(), getTodayMonth()).getOrThrow()
-    )
-    val histories: StateFlow<List<History>> get() = _histories
+    private val _monthlyHistories = MutableStateFlow(mapOf<String, List<History>>())
+    val monthlyHistories: StateFlow<Map<String, List<History>>> get() = _monthlyHistories
+
+    init {
+        getMonthlyHistories(getTodayYear(), getTodayMonth())
+    }
+
+    fun getMonthlyHistories(year: Int, month: Int) {
+        _monthlyHistories.value = repository.getMonthlyHistories(year, month).getOrThrow()
+    }
 }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/utils/DateUtil.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/utils/DateUtil.kt
@@ -10,7 +10,7 @@ fun getTodayMonthAndYear(): String {
 }
 
 fun getTodayMonthAndYear(year: Int, month: Int): String {
-    return "${year}년 ${month}월"
+    return "$year-${if (month < 10) "0$month" else month}"
 }
 
 fun getTodayMonth(): Int {


### PR DESCRIPTION
## 3개 탭 통합 ViewModel
`HistoryViewModel`에서 3개 탭(내역 / 달력 / 통계)의 중복 데이터를 관리

<br/>

## History 모델에 Not-null 칼럼 정의
date칼럼은 추가로 TEXT로 변환하여 sqlite3 내장 함수인 `substr`로 date 비교 및 매핑이 가능하다!
`('07-16' to [(History), (History), ...])` 형태로 `Map` Collection 정의하여 이용!

<br/>

## 기타
- 다빈이의 도움으로 소프트 키보드 이슈 해결
- Month의 자릿 수를 체크해 적절한 WHERE 조건문 전송

<br/>