### PR TITLE
[feat/setting to dev] 수정 가능한 설정 창을 위한 대대적인 리팩토링

### DIFF
--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSource.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSource.kt
@@ -130,6 +130,27 @@ class AccountBookDataSource @Inject constructor(
 
             insertOrThrow(PaymentMethodColumns.TABLE_NAME, null, values)
         }
+
+    fun updatePaymentMethod(
+        id: Long,
+        name: String
+    ): Int {
+        return writableDB.run {
+            val values = ContentValues().apply {
+                put(PaymentMethodColumns.COLUMN_NAME_NAME, name)
+            }
+
+            val selection = "${BaseColumns._ID} LIKE ?"
+            val selectionArgs = arrayOf(id.toString())
+
+            update(
+                PaymentMethodColumns.TABLE_NAME,
+                values,
+                selection,
+                selectionArgs
+            )
+        }
+    }
     
     fun getAllPaymentMethod(): List<PaymentMethod> 
         = readableDB.run {
@@ -172,6 +193,29 @@ class AccountBookDataSource @Inject constructor(
     
             insertOrThrow(CategoryColumns.TABLE_NAME, null, values)
         }
+
+    fun updateCategory(
+        id: Long,
+        name: String,
+        color: Long
+    ): Int {
+        return writableDB.run {
+            val values = ContentValues().apply {
+                put(CategoryColumns.COLUMN_NAME_NAME, name)
+                put(CategoryColumns.COLUMN_NAME_COLOR, color)
+            }
+
+            val selection = "${BaseColumns._ID} LIKE ?"
+            val selectionArgs = arrayOf(id.toString())
+
+            update(
+                CategoryColumns.TABLE_NAME,
+                values,
+                selection,
+                selectionArgs
+            )
+        }
+    }
 
     fun getAllExpensesCategory(): List<Category>
         = readableDB.run {

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
@@ -12,6 +12,15 @@ class AccountBookRepository @Inject constructor(
     fun getMonthlyHistories(year: Int, month: Int): Result<Map<String, List<History>>>
         = runCatching { dataSource.getAllHistory(year, month) }
 
+    fun getAllPaymentMethod(): Result<List<PaymentMethod>>
+        = runCatching { dataSource.getAllPaymentMethod() }
+
+    fun getAllExpensesCategory(): Result<List<Category>>
+            = runCatching { dataSource.getAllExpensesCategory() }
+
+    fun getAllIncomeCategory(): Result<List<Category>>
+            = runCatching { dataSource.getAllIncomeCategory() }
+
     fun insertHistory(
         type: Int,
         content: String? = null,
@@ -20,20 +29,17 @@ class AccountBookRepository @Inject constructor(
         paymentId: Long? = null,
         categoryId: Long? = null
     ): Result<Long>
-        = runCatching { dataSource.addHistory(type, content, date, amount, paymentId, categoryId) }
-
-    fun getAllPaymentMethod(): Result<List<PaymentMethod>>
-        = runCatching { dataSource.getAllPaymentMethod() }
+            = runCatching { dataSource.addHistory(type, content, date, amount, paymentId, categoryId) }
 
     fun insertPaymentMethod(name: String): Result<Long>
         = runCatching { dataSource.addPaymentMethod(name) }
 
-    fun getAllExpensesCategory(): Result<List<Category>>
-        = runCatching { dataSource.getAllExpensesCategory() }
-
-    fun getAllIncomeCategory(): Result<List<Category>>
-            = runCatching { dataSource.getAllIncomeCategory() }
-
     fun insertCategory(type: Int, name: String, color: Long): Result<Long>
         = runCatching { dataSource.addCategory(type, name, color) }
+
+    fun updatePaymentMethod(id: Long, name: String): Result<Int>
+            = runCatching { dataSource.updatePaymentMethod(id, name) }
+
+    fun updateCategory(id: Long, name: String, color: Long): Result<Int>
+            = runCatching { dataSource.updateCategory(id, name, color) }
 }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/components/Palette.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/components/Palette.kt
@@ -23,10 +23,11 @@ import com.woowacamp.android_accountbook_15.ui.theme.Purple
 @Composable
 fun Palette(
     modifier: Modifier,
+    initColor: Long? = null,
     colors: List<Long>,
     onColorSelect: (Long) -> Unit
 ) {
-    val (selectedColor, setSelectedColor) = remember { mutableStateOf(colors[0]) }
+    val (selectedColor, setSelectedColor) = remember { mutableStateOf(initColor ?: colors[0]) }
     onColorSelect(selectedColor)
 
     LazyVerticalGrid(

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/AddScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/AddScreen.kt
@@ -24,12 +24,14 @@ import com.woowacamp.android_accountbook_15.ui.theme.Yellow
 @Composable
 fun AddScreen(
     title: String,
+    writtenName: String? = null,
+    selectedColor: Long? = null,
     colors: List<Long>? = null,
     onAddClick: (String, Long?) -> Unit,
     onBackClick: () -> Unit
 ) {
-    val (name, setName) = remember { mutableStateOf("") }
-    val (color, setColor) = remember { mutableStateOf(0xFFFFFFFF) }
+    val (name, setName) = remember { mutableStateOf(writtenName ?: "") }
+    val (color, setColor) = remember { mutableStateOf(selectedColor) }
 
     Scaffold(
         topBar = {
@@ -46,8 +48,9 @@ fun AddScreen(
 
         AddScreen(
             modifier = Modifier.fillMaxWidth(),
-            colors = colors,
             text = name,
+            selectedColor = color,
+            colors = colors,
             onColorSelect = { color -> setColor(color) },
             onTextChanged = { text -> setName(text) },
             onAddClick = {
@@ -61,8 +64,9 @@ fun AddScreen(
 @Composable
 private fun AddScreen(
     modifier: Modifier,
-    colors: List<Long>?,
     text: String,
+    selectedColor: Long? = null,
+    colors: List<Long>?,
     onColorSelect: (Long) -> Unit,
     onTextChanged: (String) -> Unit,
     onAddClick: () -> Unit
@@ -102,6 +106,7 @@ private fun AddScreen(
                 Divider(color = Purple04, thickness = 1.dp)
                 Palette(
                     modifier = modifier.padding(16.dp),
+                    initColor = selectedColor,
                     colors = colors,
                     onColorSelect = onColorSelect)
             }
@@ -113,7 +118,8 @@ private fun AddScreen(
                 .padding(20.dp),
             onClick = onAddClick,
             colors = ButtonDefaults.buttonColors(backgroundColor = Yellow),
-            contentPadding = PaddingValues(16.dp)
+            contentPadding = PaddingValues(16.dp),
+            enabled = text.isNotBlank()
         ) {
             Text(text = "등록하기", color = White)
         }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/EditScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/EditScreen.kt
@@ -22,7 +22,7 @@ import com.woowacamp.android_accountbook_15.ui.theme.White
 import com.woowacamp.android_accountbook_15.ui.theme.Yellow
 
 @Composable
-fun AddScreen(
+fun EditScreen(
     title: String,
     writtenName: String? = null,
     selectedColor: Long? = null,
@@ -46,7 +46,7 @@ fun AddScreen(
             onBackClick()
         }
 
-        AddScreen(
+        EditScreen(
             modifier = Modifier.fillMaxWidth(),
             text = name,
             selectedColor = color,
@@ -62,7 +62,7 @@ fun AddScreen(
 }
 
 @Composable
-private fun AddScreen(
+private fun EditScreen(
     modifier: Modifier,
     text: String,
     selectedColor: Long? = null,

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/SettingCard.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/SettingCard.kt
@@ -1,0 +1,147 @@
+package com.woowacamp.android_accountbook_15.ui.tabs.setting
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.woowacamp.android_accountbook_15.R
+import com.woowacamp.android_accountbook_15.data.model.Category
+import com.woowacamp.android_accountbook_15.data.model.PaymentMethod
+import com.woowacamp.android_accountbook_15.ui.theme.LightPurple
+import com.woowacamp.android_accountbook_15.ui.theme.Purple
+import com.woowacamp.android_accountbook_15.ui.theme.Purple04
+import com.woowacamp.android_accountbook_15.ui.theme.White
+
+@Composable
+fun SettingCard(
+    title: String,
+    onAddClick: () -> Unit,
+    card: @Composable () -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(16.dp, 16.dp, 16.dp, 0.dp)
+    ) {
+        Text(
+            modifier = Modifier.padding(0.dp, 8.dp),
+            text = title,
+            fontSize = 16.sp,
+            color = LightPurple
+        )
+        Divider(color = Purple04, thickness = 1.dp)
+        card()
+        BottomItem(title, onAddClick)
+    }
+    Divider(color = Purple, thickness = 1.dp)
+}
+
+@Composable
+fun PaymentMethodCard(
+    paymentMethods: List<PaymentMethod>,
+    onScreenChange: (PaymentMethod) -> Unit
+) {
+    Column {
+        paymentMethods.forEach { item ->
+            SettingItem(
+                item.name,
+                onClick = { onScreenChange(item) },
+                onLongClick = {})
+        }
+    }
+}
+
+@Composable
+fun CategoryCard(
+    categories: List<Category>,
+    onScreenChange: (Category) -> Unit
+) {
+    Column {
+        categories.forEach { item ->
+            SettingItem(
+                item.name,
+                item.color,
+                onClick = { onScreenChange(item) },
+                onLongClick = {})
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun SettingItem(
+    name: String,
+    color: Long? = null,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .padding(0.dp, 11.dp)
+            .fillMaxWidth()
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick
+            )
+    ) {
+        Text(
+            modifier = Modifier.align(Alignment.CenterStart),
+            text = name,
+            fontSize = 14.sp,
+            fontWeight = FontWeight(700)
+        )
+        color?.let {
+            Text(modifier = Modifier
+                .width(56.dp)
+                .align(Alignment.CenterEnd)
+                .clip(RoundedCornerShape(14.dp))
+                .background(Color(color))
+                .padding(8.dp, 4.dp),
+                text = name,
+                color = White,
+                fontSize = 10.sp,
+                textAlign = TextAlign.Center)
+        }
+    }
+    Divider(color = Purple04, thickness = 1.dp)
+}
+
+@Composable
+private fun BottomItem(
+    title: String,
+    onAddClick: () -> Unit
+) {
+    Row(modifier = Modifier.padding(0.dp, 11.dp)) {
+        Text(
+            modifier = Modifier.weight(1f),
+            text = "$title 추가하기",
+            fontSize = 14.sp,
+            fontWeight = FontWeight(700)
+        )
+        IconButton(
+            modifier = Modifier.then(
+                Modifier
+                    .size(14.dp)
+                    .align(Alignment.CenterVertically)),
+            onClick = onAddClick
+        ) {
+            Icon(
+                painterResource(R.drawable.ic_plus),
+                ""
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/SettingScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/SettingScreen.kt
@@ -14,34 +14,33 @@ fun SettingScreen(
 
     when (screenState) {
         ScreenType.SETTING -> SettingScreen(viewModel) { type -> setScreenState(type) }
-        ScreenType.ADD_PAYMENT -> AddScreen(
+        ScreenType.ADD_PAYMENT -> EditScreen(
             title = "결제 수단 추가",
             onAddClick = { text, _ -> viewModel.insertPaymentMethod(text) },
             onBackClick = { setScreenState(ScreenType.SETTING) })
-        ScreenType.UPDATE_PAYMENT -> AddScreen(
+        ScreenType.UPDATE_PAYMENT -> EditScreen(
             title = "결제 수단 수정",
             writtenName = viewModel.payment.collectAsState().value?.name,
             onAddClick = { text, _ -> viewModel.updatePaymentMethod(text) }, // viewModel의 paymentId 변경 필요
             onBackClick = { setScreenState(ScreenType.SETTING) })
-        ScreenType.ADD_EXPENSES -> AddScreen(
+        ScreenType.ADD_EXPENSES -> EditScreen(
             title = "지출 카테고리 추가",
             colors = expensesColors,
             onAddClick = { text, color -> viewModel.insertExpensesCategory(text, color!!) },
             onBackClick = { setScreenState(ScreenType.SETTING) })
-        ScreenType.UPDATE_EXPENSES -> AddScreen(
+        ScreenType.UPDATE_EXPENSES -> EditScreen(
             title = "지출 카테고리 수정",
             writtenName = viewModel.category.collectAsState().value?.name,
             selectedColor = viewModel.category.collectAsState().value?.color,
             colors = expensesColors,
             onAddClick = { text, color -> viewModel.updateCategory(text, color!!) },
             onBackClick = { setScreenState(ScreenType.SETTING) })
-        ScreenType.ADD_INCOME -> AddScreen(
+        ScreenType.ADD_INCOME -> EditScreen(
             title = "수입 카테고리 추가",
-            writtenName = viewModel.payment.collectAsState().value?.name,
             colors = incomeColors,
             onAddClick = { text, color -> viewModel.insertIncomeCategory(text, color!!) },
             onBackClick = { setScreenState(ScreenType.SETTING) })
-        ScreenType.UPDATE_INCOME -> AddScreen(
+        ScreenType.UPDATE_INCOME -> EditScreen(
             title = "지출 카테고리 수정",
             writtenName = viewModel.category.collectAsState().value?.name,
             selectedColor = viewModel.category.collectAsState().value?.color,

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/SettingScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/SettingScreen.kt
@@ -1,27 +1,8 @@
 package com.woowacamp.android_accountbook_15.ui.tabs.setting
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment.Companion.CenterEnd
-import androidx.compose.ui.Alignment.Companion.CenterStart
-import androidx.compose.ui.Alignment.Companion.CenterVertically
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.woowacamp.android_accountbook_15.R
-import com.woowacamp.android_accountbook_15.data.model.Category
-import com.woowacamp.android_accountbook_15.data.model.PaymentMethod
 import com.woowacamp.android_accountbook_15.ui.components.Header
 import com.woowacamp.android_accountbook_15.ui.theme.*
 
@@ -118,125 +99,6 @@ private fun SettingScreen(
                         })
                 }
             }
-        }
-    }
-}
-
-@Composable
-fun SettingCard(
-    title: String,
-    onAddClick: () -> Unit,
-    card: @Composable () -> Unit
-) {
-    Column(
-        modifier = Modifier.padding(16.dp, 16.dp, 16.dp, 0.dp)
-    ) {
-        Text(
-            modifier = Modifier.padding(0.dp, 8.dp),
-            text = title,
-            fontSize = 16.sp,
-            color = LightPurple
-        )
-        Divider(color = Purple04, thickness = 1.dp)
-        card()
-        BottomItem(title, onAddClick)
-    }
-    Divider(color = Purple, thickness = 1.dp)
-}
-
-@Composable
-private fun PaymentMethodCard(
-    paymentMethods: List<PaymentMethod>,
-    onScreenChange: (PaymentMethod) -> Unit
-) {
-    Column {
-        paymentMethods.forEach { item ->
-            SettingItem(
-                item.name,
-                onClick = { onScreenChange(item) },
-                onLongClick = {})
-        }
-    }
-}
-
-@Composable
-private fun CategoryCard(
-    categories: List<Category>,
-    onScreenChange: (Category) -> Unit
-) {
-    Column {
-        categories.forEach { item ->
-            SettingItem(
-                item.name,
-                item.color,
-                onClick = { onScreenChange(item) },
-                onLongClick = {})
-        }
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun SettingItem(
-    name: String,
-    color: Long? = null,
-    onClick: () -> Unit,
-    onLongClick: () -> Unit
-) {
-    Box(
-        modifier = Modifier
-            .padding(0.dp, 11.dp)
-            .fillMaxWidth()
-            .combinedClickable(
-                onClick = onClick,
-                onLongClick = onLongClick
-            )
-    ) {
-        Text(
-            modifier = Modifier.align(CenterStart),
-            text = name,
-            fontSize = 14.sp,
-            fontWeight = FontWeight(700)
-        )
-        color?.let {
-            Text(modifier = Modifier
-                .width(56.dp)
-                .align(CenterEnd)
-                .clip(RoundedCornerShape(14.dp))
-                .background(Color(color))
-                .padding(8.dp, 4.dp),
-                text = name,
-                color = White,
-                fontSize = 10.sp,
-                textAlign = TextAlign.Center)
-        }
-    }
-    Divider(color = Purple04, thickness = 1.dp)
-}
-
-@Composable
-private fun BottomItem(
-    title: String,
-    onAddClick: () -> Unit
-) {
-    Row(modifier = Modifier.padding(0.dp, 11.dp)) {
-        Text(
-            modifier = Modifier.weight(1f),
-            text = "$title 추가하기",
-            fontSize = 14.sp,
-            fontWeight = FontWeight(700)
-        )
-        IconButton(
-            modifier = Modifier.then(
-                Modifier
-                    .size(14.dp)
-                    .align(CenterVertically)),
-            onClick = onAddClick
-        ) {
-            Icon(
-                painterResource(R.drawable.ic_plus),
-                ""
-            )
         }
     }
 }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/SettingViewModel.kt
@@ -54,6 +54,28 @@ class SettingViewModel @Inject constructor(
         val incomeCategories = repository.getAllIncomeCategory().getOrThrow()
         _state.value.incomeCategories = incomeCategories
     }
+
+    fun updatePaymentMethod(id: Long, name: String) {
+        val res = repository.updatePaymentMethod(id, name).getOrNull()
+        if (res == null) {
+            createToast("이미 등록된 결제 수단입니다")
+            return
+        }
+        val paymentMethods = repository.getAllPaymentMethod().getOrThrow()
+        _state.value.paymentMethods = paymentMethods
+    }
+
+    fun updateCategory(id: Long, name: String, color: Long) {
+        val res = repository.updateCategory(id, name, color).getOrNull()
+        if (res == null) {
+            createToast("이미 등록된 카테고리입니다")
+            return
+        }
+        val expensesCategories = repository.getAllExpensesCategory().getOrThrow()
+        val incomeCategories = repository.getAllIncomeCategory().getOrThrow()
+        _state.value.expensesCategories = expensesCategories
+        _state.value.incomeCategories = incomeCategories
+    }
 }
 
 data class SettingViewState(

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/SettingViewModel.kt
@@ -18,12 +18,18 @@ class SettingViewModel @Inject constructor(
     private val _state = MutableStateFlow(SettingViewState())
     val state: StateFlow<SettingViewState> get() = _state
 
+    private val paymentId = MutableStateFlow(-1L)
+    private val categoryId = MutableStateFlow(-1L)
+
     init {
         val paymentMethods = repository.getAllPaymentMethod().getOrThrow()
         val expensesCategories = repository.getAllExpensesCategory().getOrThrow()
         val incomeCategories = repository.getAllIncomeCategory().getOrThrow()
         _state.value = SettingViewState(paymentMethods, expensesCategories, incomeCategories)
     }
+
+    fun setPaymentId(id: Long) { paymentId.value = id }
+    fun setCategoryId(id: Long) { categoryId.value = id }
 
     fun insertPaymentMethod(name: String) {
         val res = repository.insertPaymentMethod(name).getOrNull()
@@ -55,8 +61,8 @@ class SettingViewModel @Inject constructor(
         _state.value.incomeCategories = incomeCategories
     }
 
-    fun updatePaymentMethod(id: Long, name: String) {
-        val res = repository.updatePaymentMethod(id, name).getOrNull()
+    fun updatePaymentMethod(name: String) {
+        val res = repository.updatePaymentMethod(paymentId.value, name).getOrNull()
         if (res == null) {
             createToast("이미 등록된 결제 수단입니다")
             return
@@ -65,8 +71,8 @@ class SettingViewModel @Inject constructor(
         _state.value.paymentMethods = paymentMethods
     }
 
-    fun updateCategory(id: Long, name: String, color: Long) {
-        val res = repository.updateCategory(id, name, color).getOrNull()
+    fun updateCategory(name: String, color: Long) {
+        val res = repository.updateCategory(categoryId.value, name, color).getOrNull()
         if (res == null) {
             createToast("이미 등록된 카테고리입니다")
             return

--- a/app/src/main/res/drawable/ic_checkbox.xml
+++ b/app/src/main/res/drawable/ic_checkbox.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="22dp"
+    android:height="22dp"
+    android:viewportWidth="22"
+    android:viewportHeight="22">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M3.653,0.714H18.347C19.126,0.714 19.874,1.024 20.425,1.575C20.976,2.126 21.286,2.874 21.286,3.653V18.347C21.286,19.126 20.976,19.874 20.425,20.425C19.874,20.976 19.126,21.286 18.347,21.286H3.653C2.874,21.286 2.126,20.976 1.575,20.425C1.024,19.874 0.714,19.126 0.714,18.347V3.653C0.714,2.874 1.024,2.126 1.575,1.575C2.126,1.024 2.874,0.714 3.653,0.714V0.714Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:fillType="evenOdd"
+      android:strokeColor="#524D90"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_checkedbox.xml
+++ b/app/src/main/res/drawable/ic_checkedbox.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4.653,1.714H19.347C20.126,1.714 20.874,2.024 21.425,2.575C21.976,3.126 22.286,3.874 22.286,4.653V19.347C22.286,20.126 21.976,20.874 21.425,21.425C20.874,21.976 20.126,22.286 19.347,22.286H4.653C3.874,22.286 3.126,21.976 2.575,21.425C2.024,20.874 1.714,20.126 1.714,19.347V4.653C1.714,3.874 2.024,3.126 2.575,2.575C3.126,2.024 3.874,1.714 4.653,1.714Z"
+      android:fillColor="#E75B3F"
+      android:fillType="evenOdd"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M7.592,12L10.531,14.939L16.408,9.061"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_trash.xml
+++ b/app/src/main/res/drawable/ic_trash.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="20dp"
+    android:viewportWidth="18"
+    android:viewportHeight="20">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M1,3.143H17M6.714,6.571V15.714M11.286,6.571V15.714M3.286,3.143H14.714V16.857C14.714,17.463 14.474,18.045 14.045,18.473C13.616,18.902 13.035,19.143 12.429,19.143H5.571C4.965,19.143 4.384,18.902 3.955,18.473C3.527,18.045 3.286,17.463 3.286,16.857V3.143ZM9,0.857C9.577,0.857 10.132,1.075 10.555,1.467C10.978,1.859 11.237,2.396 11.28,2.971L11.286,3.143H6.714C6.714,2.537 6.955,1.955 7.384,1.527C7.812,1.098 8.394,0.857 9,0.857V0.857Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#E75B3F"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
- Data Layer에 수정 기능 작성됨
- ViewModel에서 당장 수정할 객체 정의됨
- 수정 기능 이용 시 기존 데이터를 화면에 표시할 수 있도록 함
- 일부 아이콘 추가
- 삭제 기능은 요구사항에 없었기 때문에 추후에 시간이 나면 추가할 예정

<br/><br/>

## ViewModel에서 당장 수정할 "임시" 객체가 정의된 이유
나의 프로젝트는 All Compose 프로젝트가 아니다. 그렇기 때문에 Jetpack Navigation을 이용할 수 없으므로 `Fragment`를 이용한다. `Fragment`를 이용하게 되면 한 탭에서 여러 화면을 교체한다는 것이 깔끔한 작업이 아니다. 물론 프래그먼트 여러 개를 선언해서 `ViewPagerAdapter`에서 깊은 커플링을 무시하고 전환을 구현할 수는 있을 것 같다. 하지만 Compose로 화면 유형 상태를 받아와 명확한 로직으로 교체만 해주면 더 간단하게 해결할 수 있다. 그래서 나는 그 방법을 택했다!
**하지만 거기서 또 문제가 생겼다.** 변경된 두 번째 Child Screen이 기존 Child Screen의 하위 리스트 요소 중 하나가 갖는 정보를 알아내는 것은 굉장히 복잡하고 멀리 돌아가야하는 것이었다.
예를 들어, 지출 카테고리의 5 번째 항목이 가진 Category(5, 0, "쇼핑/뷰티", 0xFF4CB8B8) 라는 정보를 전혀 다른 1depth Child Screen에게 전달할 때 나는 아주 단순하게도 아래와 같은 로직을 떠올렸다.
<img width="1103" alt="image" src="https://user-images.githubusercontent.com/47631768/182029626-db05ba40-2d1d-4f31-921a-49b03454cf70.png">
....너무나도 마음에 들지 않았다.... 심지어 버그가 터졌는데 어디서 문제가 생겼는지도 알 수 없을 정도였다. 그래서 머리를 싸매다 고안해 낸 방법이 결국 `ViewModel`에 일시적으로 저장되는 temp객체를 두어 viewModel에서 알아서 하도록 냅두자! 였다. 괜찮은 발상인지는 모르겠다.
Jetpack Navigation을 이용했다면 NavController에 단순히 정보를 전달하면 될 것 같은데... 나는 잘못된 선택을 한 것 같다. 왜 굳이 Compose에 최적화된 Navigation을 두고 `Fragment + 나머지 모두 Compose` 를 택하게 되었나.. 후회중이다.

<br/>