### PR TITLE
[Main] 화면의 자잘한 문제들 해결 & 디자인 수정

### DIFF
--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/components/Item.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/components/Item.kt
@@ -12,8 +12,10 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -71,7 +73,6 @@ fun DateSpinnerItem(
 fun InputItem(
     label: String,
     value: String,
-    numeric: Boolean = false,
     onTextChanged: (String) -> Unit
 ) {
     Row(modifier = Modifier
@@ -86,15 +87,7 @@ fun InputItem(
         BasicTextField(
             modifier = Modifier.weight(1f),
             value = value,
-            onValueChange = {
-                if (!numeric)
-                    onTextChanged(it)
-                else if (it.isEmpty())
-                    onTextChanged("0")
-                else if (it.length < 12) {
-                    onTextChanged(it.toMoneyInt().toMoneyString())
-                }
-            },
+            onValueChange = { onTextChanged(it) },
             singleLine = true,
             textStyle = TextStyle(color = Purple),
             decorationBox = { innerTextField ->
@@ -107,8 +100,51 @@ fun InputItem(
                     }
                 }
                 innerTextField()
+            })
+    }
+    Divider(color = Purple04, thickness = 1.dp, modifier = Modifier.padding(0.dp, 0.dp, 0.dp, 8.dp))
+}
+
+@Composable
+fun MoneyInputItem(
+    label: String,
+    value: TextFieldValue,
+    onTextChanged: (TextFieldValue) -> Unit
+) {
+    Row(modifier = Modifier
+        .fillMaxWidth()
+        .padding(0.dp, 8.dp)) {
+        Text(
+            modifier = Modifier
+                .align(CenterVertically)
+                .width(76.dp),
+            text = label,
+            fontSize = 14.sp)
+        BasicTextField(
+            modifier = Modifier.weight(1f),
+            value = value,
+            onValueChange = {
+                if (it.text.isEmpty())
+                    onTextChanged(TextFieldValue("0", selection = TextRange(1)))
+                else if (it.text.length < 12) {
+                    val moneyString = it.text.toMoneyInt().toMoneyString()
+                    onTextChanged(TextFieldValue(moneyString, selection = TextRange(moneyString.length)))
+                }
             },
-            keyboardOptions = KeyboardOptions(keyboardType = if (numeric) KeyboardType.Number else KeyboardType.Text))
+            singleLine = true,
+            textStyle = TextStyle(color = Purple),
+            decorationBox = { innerTextField ->
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    if (value.text.isEmpty()) {
+                        Text(
+                            text = "입력하세요",
+                            color = LightPurple,
+                            fontSize = 14.sp)
+                    }
+                }
+                innerTextField()
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number))
     }
     Divider(color = Purple04, thickness = 1.dp, modifier = Modifier.padding(0.dp, 0.dp, 0.dp, 8.dp))
 }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/calendar/CalendarCard.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/calendar/CalendarCard.kt
@@ -17,6 +17,7 @@ import com.woowacamp.android_accountbook_15.ui.theme.*
 import com.woowacamp.android_accountbook_15.utils.getDaysOfMonth
 import com.woowacamp.android_accountbook_15.utils.getMonthAndDateKorean
 import com.woowacamp.android_accountbook_15.utils.isToday
+import com.woowacamp.android_accountbook_15.utils.toMoneyString
 import kotlin.math.ceil
 
 @Composable
@@ -51,12 +52,16 @@ fun CalendarCard(
                         else
                             0
                     CalendarItem(
-                        modifier = Modifier.weight(1f).height(80.dp),
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(80.dp),
                         isToday = isToday(year, curM, days[i]),
                         isTodayMonth = curM == month,
                         date = days[i],
                         totalIncome, totalExpenses)
-                    if ((i+1)%7>0) Divider(color = LightPurple, modifier = Modifier.height(80.dp).width(1.dp))
+                    if ((i+1)%7>0) Divider(color = LightPurple, modifier = Modifier
+                        .height(80.dp)
+                        .width(1.dp))
 
                     i++
                     if (i >= days.size) break
@@ -82,9 +87,9 @@ fun CalendarItem(
             .padding(4.dp)
     ) {
         Column(modifier = Modifier.align(Alignment.TopStart)) {
-            if (totalIncome != 0) Text(text = totalIncome.toString(), fontSize = 8.sp, color = Blue)
-            if (totalExpenses != 0) Text(text = "-$totalExpenses", fontSize = 8.sp, color = Red)
-            if (totalIncome != 0 || totalExpenses != 0) Text(text = (totalIncome-totalExpenses).toString(), fontSize = 8.sp)
+            if (totalIncome != 0) Text(text = totalIncome.toMoneyString(), fontSize = 8.sp, color = Blue)
+            if (totalExpenses != 0) Text(text = "-${totalExpenses.toMoneyString()}", fontSize = 8.sp, color = Red)
+            if (totalIncome != 0 || totalExpenses != 0) Text(text = (totalIncome-totalExpenses).toMoneyString(), fontSize = 8.sp)
         }
         Text(
             modifier = Modifier.align(Alignment.BottomEnd),

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/calendar/CalendarScreen.kt
@@ -2,11 +2,8 @@ package com.woowacamp.android_accountbook_15.ui.tabs.calendar
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.*
@@ -22,7 +19,6 @@ import com.woowacamp.android_accountbook_15.ui.theme.Blue
 import com.woowacamp.android_accountbook_15.ui.theme.LightPurple
 import com.woowacamp.android_accountbook_15.ui.theme.Purple
 import com.woowacamp.android_accountbook_15.ui.theme.Red
-import com.woowacamp.android_accountbook_15.utils.getDaysOfMonth
 import com.woowacamp.android_accountbook_15.utils.getMonthAndYearKorean
 
 @Composable
@@ -72,14 +68,11 @@ fun CalendarScreen(
 
             val totalIncome = histories.values.sumOf { list -> list.sumOf { if (it.type == 1) it.amount else 0 } }
             val totalExpenses = histories.values.sumOf { list -> list.sumOf { if (it.type == 0) it.amount else 0 } }
-            StatisticsItem(label = "수입", amountColor = Blue,
-                amount = totalIncome)
+            StatisticsItem(label = "수입", amountColor = Blue, amount = totalIncome)
             Divider(modifier = Modifier.padding(16.dp, 0.dp), color = LightPurple, thickness = 1.dp)
-            StatisticsItem(label = "지출", amountColor = Red,
-                amount = totalExpenses*-1)
+            StatisticsItem(label = "지출", amountColor = Red, amount = totalExpenses*-1)
             Divider(modifier = Modifier.padding(16.dp, 0.dp), color = LightPurple, thickness = 1.dp)
-            StatisticsItem(label = "총합", amountColor = Purple,
-                amount = totalIncome-totalExpenses)
+            StatisticsItem(label = "총합", amountColor = Purple, amount = totalIncome-totalExpenses)
         }
     }
 

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/EditScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/EditScreen.kt
@@ -23,10 +23,7 @@ import com.woowacamp.android_accountbook_15.data.model.History
 import com.woowacamp.android_accountbook_15.data.model.PaymentMethod
 import com.woowacamp.android_accountbook_15.ui.components.*
 import com.woowacamp.android_accountbook_15.ui.tabs.setting.SettingViewModel
-import com.woowacamp.android_accountbook_15.ui.theme.LightPurple
-import com.woowacamp.android_accountbook_15.ui.theme.Purple
-import com.woowacamp.android_accountbook_15.ui.theme.White
-import com.woowacamp.android_accountbook_15.ui.theme.Yellow
+import com.woowacamp.android_accountbook_15.ui.theme.*
 import com.woowacamp.android_accountbook_15.utils.*
 
 @Composable
@@ -115,7 +112,7 @@ fun EditScreen(
                         )
                     )
                 },
-                colors = ButtonDefaults.buttonColors(backgroundColor = Yellow),
+                colors = ButtonDefaults.buttonColors(backgroundColor = Yellow, disabledBackgroundColor = Yellow05),
                 contentPadding = PaddingValues(16.dp),
                 enabled = date.isNotBlank() && amount.text.isNotBlank() && amount.text != "0" && (isSelectedIncome || paymentMethod.isNotBlank())
             ) {

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/EditScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/EditScreen.kt
@@ -46,13 +46,12 @@ fun EditScreen(
     ) }
 
     val (date, setDate) = remember { mutableStateOf(if (history != null) changeHyphenToKorean(history.date) else getTodayKorean()) }
-    val (amount, setAmount) = remember { mutableStateOf(history?.amount?.toString() ?: "") }
+    val (amount, setAmount) = remember { mutableStateOf(TextFieldValue(history?.amount?.toString() ?: "")) }
     val (paymentMethod, setPaymentMethod) = remember { mutableStateOf(history?.payment?.name ?: "") }
     val (category, setCategory) = remember { mutableStateOf(history?.category?.name ?: "") }
     val (paymentId, setPaymentId) = remember { mutableStateOf(history?.payment?.id ?: -1L) }
     val (categoryId, setCategoryId) = remember { mutableStateOf(history?.category?.id ?: -1L) }
     val (content, setContent) = remember { mutableStateOf(history?.content ?: "") }
-    val (money, setMoney) = remember { mutableStateOf(TextFieldValue(history?.amount?.toString() ?: "")) }
 
     val (isDateOpened, setDateOpened) = remember { mutableStateOf(false) }
     val (isPaymentOpened, setPaymentOpened) = remember { mutableStateOf(false) }
@@ -87,8 +86,8 @@ fun EditScreen(
                     .fillMaxWidth()
                     .weight(1f),
                 isSelectedExpenses = !isSelectedIncome,
-                date, money, paymentMethod, category, content,
-                setDate, setMoney, setPaymentMethod, setCategory, setPaymentId, setCategoryId, setContent,
+                date, amount, paymentMethod, category, content,
+                setDate, setAmount, setPaymentMethod, setCategory, setPaymentId, setCategoryId, setContent,
                 isDateOpened, isPaymentOpened, isCategoryOpened,
                 setDateOpened, setPaymentOpened, setCategoryOpened,
                 onAddPayment = { viewModel.insertPaymentMethod(it) },
@@ -109,7 +108,7 @@ fun EditScreen(
                             -1,
                             isIncome,
                             date = changeKoreanToHyphen(date),
-                            amount = amount.toMoneyInt(),
+                            amount = amount.text.toMoneyInt(),
                             payment = PaymentMethod(paymentId, paymentMethod),
                             category = Category(categoryId, isIncome, category, 0x0),
                             content = content
@@ -118,7 +117,7 @@ fun EditScreen(
                 },
                 colors = ButtonDefaults.buttonColors(backgroundColor = Yellow),
                 contentPadding = PaddingValues(16.dp),
-                enabled = date.isNotBlank() && amount.isNotBlank() && amount != "0" && (isSelectedIncome || paymentMethod.isNotBlank())
+                enabled = date.isNotBlank() && amount.text.isNotBlank() && amount.text != "0" && (isSelectedIncome || paymentMethod.isNotBlank())
             ) {
                 Text(text = "등록하기", color = White)
             }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/EditScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/EditScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -19,10 +21,7 @@ import com.woowacamp.android_accountbook_15.R
 import com.woowacamp.android_accountbook_15.data.model.Category
 import com.woowacamp.android_accountbook_15.data.model.History
 import com.woowacamp.android_accountbook_15.data.model.PaymentMethod
-import com.woowacamp.android_accountbook_15.ui.components.DateSpinnerItem
-import com.woowacamp.android_accountbook_15.ui.components.Header
-import com.woowacamp.android_accountbook_15.ui.components.InputItem
-import com.woowacamp.android_accountbook_15.ui.components.SpinnerItem
+import com.woowacamp.android_accountbook_15.ui.components.*
 import com.woowacamp.android_accountbook_15.ui.tabs.setting.SettingViewModel
 import com.woowacamp.android_accountbook_15.ui.theme.LightPurple
 import com.woowacamp.android_accountbook_15.ui.theme.Purple
@@ -53,6 +52,7 @@ fun EditScreen(
     val (paymentId, setPaymentId) = remember { mutableStateOf(history?.payment?.id ?: -1L) }
     val (categoryId, setCategoryId) = remember { mutableStateOf(history?.category?.id ?: -1L) }
     val (content, setContent) = remember { mutableStateOf(history?.content ?: "") }
+    val (money, setMoney) = remember { mutableStateOf(TextFieldValue(history?.amount?.toString() ?: "")) }
 
     val (isDateOpened, setDateOpened) = remember { mutableStateOf(false) }
     val (isPaymentOpened, setPaymentOpened) = remember { mutableStateOf(false) }
@@ -87,8 +87,8 @@ fun EditScreen(
                     .fillMaxWidth()
                     .weight(1f),
                 isSelectedExpenses = !isSelectedIncome,
-                date, amount, paymentMethod, category, content,
-                setDate, setAmount, setPaymentMethod, setCategory, setPaymentId, setCategoryId, setContent,
+                date, money, paymentMethod, category, content,
+                setDate, setMoney, setPaymentMethod, setCategory, setPaymentId, setCategoryId, setContent,
                 isDateOpened, isPaymentOpened, isCategoryOpened,
                 setDateOpened, setPaymentOpened, setCategoryOpened,
                 onAddPayment = { viewModel.insertPaymentMethod(it) },
@@ -170,12 +170,12 @@ private fun EditScreen(
     modifier: Modifier,
     isSelectedExpenses: Boolean,
     date: String,
-    amount: String,
+    amount: TextFieldValue,
     paymentMethod: String,
     category: String,
     content: String,
     onDateChanged: (String) -> Unit,
-    onAmountChanged: (String) -> Unit,
+    onAmountChanged: (TextFieldValue) -> Unit,
     onPaymentChanged: (String) -> Unit,
     onCategoryChanged: (String) -> Unit,
     onPaymentIdChanged: (Long) -> Unit,
@@ -205,11 +205,10 @@ private fun EditScreen(
                     requestToOpen = isDateOpened,
                     onOpen = setDateOpened,
                     onTextChanged = onDateChanged)
-                InputItem(
+                MoneyInputItem(
                     label = "금액",
                     value = amount,
-                    onTextChanged = onAmountChanged,
-                    numeric = true)
+                    onTextChanged = onAmountChanged)
                 if (isSelectedExpenses)
                     SpinnerItem(
                         label = "결제 수단",

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/HistoryScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/HistoryScreen.kt
@@ -149,6 +149,7 @@ private fun HistoryScreen(
                 modifier = Modifier
                     .padding(16.dp)
                     .fillMaxWidth(),
+                selectMode = selectMode,
                 totalIncome = totalIncome,
                 totalExpenses = totalExpenses,
                 isSelectedIncome = isSelectedIncome,
@@ -208,6 +209,7 @@ private fun HistoryScreen(
 @Composable
 private fun TypeCheckBoxGroup(
     modifier: Modifier,
+    selectMode: Boolean,
     totalIncome: Int,
     totalExpenses: Int,
     isSelectedIncome: Boolean,
@@ -222,10 +224,11 @@ private fun TypeCheckBoxGroup(
         Row(
             modifier = Modifier
                 .weight(1f)
-                .background(if (isSelectedIncome) Purple else LightPurple)
+                .background(if (isSelectedIncome && !selectMode) Purple else LightPurple)
                 .padding(8.dp)
                 .clickable {
-                    onIncomeClick(!isSelectedIncome)
+                    if (!selectMode)
+                        onIncomeClick(!isSelectedIncome)
                 },
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
@@ -241,10 +244,11 @@ private fun TypeCheckBoxGroup(
         Row(
             modifier = Modifier
                 .weight(1f)
-                .background(if (isSelectedExpenses) Purple else LightPurple)
+                .background(if (isSelectedExpenses && !selectMode) Purple else LightPurple)
                 .padding(8.dp)
                 .clickable {
-                    onExpensesClick(!isSelectedExpenses)
+                    if (!selectMode)
+                        onExpensesClick(!isSelectedExpenses)
                 },
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/EditScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/setting/EditScreen.kt
@@ -17,10 +17,7 @@ import com.woowacamp.android_accountbook_15.R
 import com.woowacamp.android_accountbook_15.ui.components.Header
 import com.woowacamp.android_accountbook_15.ui.components.InputItem
 import com.woowacamp.android_accountbook_15.ui.components.Palette
-import com.woowacamp.android_accountbook_15.ui.theme.LightPurple
-import com.woowacamp.android_accountbook_15.ui.theme.Purple04
-import com.woowacamp.android_accountbook_15.ui.theme.White
-import com.woowacamp.android_accountbook_15.ui.theme.Yellow
+import com.woowacamp.android_accountbook_15.ui.theme.*
 
 @Composable
 fun EditScreen(
@@ -107,7 +104,7 @@ private fun EditScreen(
                 .align(Alignment.BottomCenter)
                 .padding(20.dp),
             onClick = onAddClick,
-            colors = ButtonDefaults.buttonColors(backgroundColor = Yellow),
+            colors = ButtonDefaults.buttonColors(backgroundColor = Yellow, disabledBackgroundColor = Yellow05),
             contentPadding = PaddingValues(16.dp),
             enabled = text.isNotBlank()
         ) {

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/theme/Color.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/theme/Color.kt
@@ -16,6 +16,7 @@ val White = Color(0xFFFFFFFF)
 val White05 = Color(0x7FFFFFFF)
 
 val Yellow = Color(0xFFF5B853)
+val Yellow05 = Color(0x80F5B853)
 val Red = Color(0xFFE75B3F)
 val Blue = Color(0xFF4EAABA)
 val Grey1 = Color(0xFF3F3F3F)

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/utils/DateUtil.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/utils/DateUtil.kt
@@ -119,12 +119,12 @@ fun getDaysOfMonth(year: Int, month: Int): List<Int> {
     for (i in getDayCount(year, month) downTo 1)
         res.add(i) // ex) [31, 30, 29, ..., 1]
 
-    var prevMonthDayCount = getDayCount(year, month-1)
+    var newY = if (month-1 > 0) year else year-1
+    var newM = if (month-1 > 0) month-1 else 12
+    var prevMonthDayCount = getDayCount(newY, newM)
     if (getDay(year, month, res.last()) != "일") { // 이번 달의 1일은 일요일인가?
         res.add(prevMonthDayCount)
         prevMonthDayCount--
-        val newY = if (month-1 > 0) year else year-1
-        val newM = if (month-1 > 0) month-1 else 12
         while (getDay(newY, newM, res.last()) != "일") { // 첫 주의 시작은 일요일로!
             res.add(prevMonthDayCount)
             prevMonthDayCount--
@@ -133,12 +133,12 @@ fun getDaysOfMonth(year: Int, month: Int): List<Int> {
 
     res.reverse() // ex) [31, 1, 2, ..., 30, 31]
 
+    newY = if (month+1 > 12) year+1 else year
+    newM = if (month+1 > 12) 1 else month+1
     var nextMonthDay = 1
     if (getDay(year, month, res.last()) != "토") { // 마지막 요일 확인!
         res.add(nextMonthDay)
         nextMonthDay++
-        val newY = if (month+1 > 12) year+1 else year
-        val newM = if (month+1 > 12) 1 else month+1
         while (getDay(newY, newM, res.last()) != "토") { // 마지막 주의 끝은 토요일로!
             res.add(nextMonthDay)
             nextMonthDay++

--- a/app/src/main/res/drawable/ic_checkedbox.xml
+++ b/app/src/main/res/drawable/ic_checkedbox.xml
@@ -1,17 +1,22 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:width="22dp"
+    android:height="22dp"
+    android:viewportWidth="20.571"
+    android:viewportHeight="20.571">
   <path
-      android:pathData="M4.653,1.714H19.347C20.126,1.714 20.874,2.024 21.425,2.575C21.976,3.126 22.286,3.874 22.286,4.653V19.347C22.286,20.126 21.976,20.874 21.425,21.425C20.874,21.976 20.126,22.286 19.347,22.286H4.653C3.874,22.286 3.126,21.976 2.575,21.425C2.024,20.874 1.714,20.126 1.714,19.347V4.653C1.714,3.874 2.024,3.126 2.575,2.575C3.126,2.024 3.874,1.714 4.653,1.714Z"
-      android:fillColor="#E75B3F"
-      android:fillType="evenOdd"/>
-  <path
+      android:pathData="M2.943,0.004L17.637,0.004C18.416,0.004 19.164,0.314 19.715,0.865C20.266,1.416 20.576,2.164 20.576,2.943L20.576,17.637C20.576,18.416 20.266,19.164 19.715,19.715C19.164,20.266 18.416,20.576 17.637,20.576L2.943,20.576C2.164,20.576 1.416,20.266 0.865,19.715C0.314,19.164 0.004,18.416 0.004,17.637L0.004,2.943C0.004,2.164 0.314,1.416 0.865,0.865C1.416,0.314 2.164,0.004 2.943,0.004Z"
+      android:strokeLineJoin="miter"
       android:strokeWidth="1"
-      android:pathData="M7.592,12L10.531,14.939L16.408,9.061"
+      android:fillColor="#E75B3F"
+      android:fillType="evenOdd"
+      android:strokeColor="#00000000"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="M5.592,11L8.531,13.939L14.408,8.061"
       android:strokeLineJoin="round"
+      android:strokeWidth="1"
       android:fillColor="#00000000"
-      android:strokeColor="#ffffff"
+      android:fillType="nonZero"
+      android:strokeColor="#FFFFFF"
       android:strokeLineCap="round"/>
 </vector>


### PR DESCRIPTION
## 금액 입력 후 포맷 적용 시 포커싱 문제
- 포맷이 적용되는 순간에 입력 Cursor의 포커스가 이상한 위치로 가게 되었다.
- 광민님이 Value를 어떤 객체로 변경하면 된다고 하시는 이야기를 듣고 찾아 본 결과
`TextFieldValue`라고 문자 `text`와 커서 위치 `selection` 속성을 가지는 객체가 존재했다.
- `onTextChanged `시에, `selection`에 `TextRange`로 포커싱할 위치를 지정해주면 된다.
``` Kotlin
val moneyString = it.text.toMoneyInt().toMoneyString()
onTextChanged(TextFieldValue(moneyString, selection = TextRange(moneyString.length)))
```

<br/><br/>

## 체크 박스 svg 파일의 하자(?)
- Figma에서 Export 기능으로 제공되는 아이콘이 통합된 하나의 이미지가 아니라, 박스 + 체크 로 분리가 되어있던 게 문제였다.
- 앱의 삭제 모드에서 체크와 해제를 반복 하면 아이콘 자체의 크기가 달라 뷰가 좌우로 들썩인다..
- 그래서 Export를 하면 상하좌우에 마진이 남은 가로세로 24px 이미지가 다운로드 되는데, 사실 아이콘 자체의 크기는 20.571px 이었다.
- 나는 이미지 편집기가 없기 때문에 Vectr라고 하는 온라인 편집 사이트를 이용해서 이미지 크기를 조정했다.
- 이제 뷰가 좌우로 들썩이지 않는다.....

<br/><br/>