### PR TITLE
[Graph] 상세 직선 그래프 화면 구현

### DIFF
--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSource.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSource.kt
@@ -38,6 +38,12 @@ interface AccountBookDataSource {
         categoryId: Long
     ): Map<String, List<History>>
 
+    fun readMonthlyTotalAmount(
+        startYear: Int, startMonth: Int,
+        endYear: Int, endMonth: Int,
+        categoryId: Long
+    ): List<Pair<Int, Int>>
+
     fun readAllPaymentMethod(): List<PaymentMethod>
 
     fun readAllExpensesCategory(): List<Category>

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSource.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSource.kt
@@ -32,6 +32,12 @@ interface AccountBookDataSource {
         month: Int
     ): Map<String, List<History>>
 
+    fun readHistoriesEachCategory(
+        year: Int,
+        month: Int,
+        categoryId: Long
+    ): List<History>
+
     fun readAllPaymentMethod(): List<PaymentMethod>
 
     fun readAllExpensesCategory(): List<Category>

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSource.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSource.kt
@@ -36,7 +36,7 @@ interface AccountBookDataSource {
         year: Int,
         month: Int,
         categoryId: Long
-    ): List<History>
+    ): Map<String, List<History>>
 
     fun readAllPaymentMethod(): List<PaymentMethod>
 

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSource.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSource.kt
@@ -42,7 +42,7 @@ interface AccountBookDataSource {
         startYear: Int, startMonth: Int,
         endYear: Int, endMonth: Int,
         categoryId: Long
-    ): List<Pair<Int, Int>>
+    ): List<Pair<Int, Long>>
 
     fun readAllPaymentMethod(): List<PaymentMethod>
 

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSourceImpl.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSourceImpl.kt
@@ -166,11 +166,11 @@ class AccountBookDataSourceImpl @Inject constructor(
                         val amount = getLong(getColumnIndexOrThrow("total_amount"))
 
                         val month = date.split("-")[1].toInt() // 2000-09 --> 9
-                        while (month > currentMonth) { // 7~12월까지인데 10, 12월만 데이터가 있다면 7,8,9,11 월에는 0 넣기
+                        while (month != currentMonth) { // 7~12월까지인데 10, 12월만 데이터가 있다면 7,8,9,11 월에는 0 넣기
                             add(Pair(currentMonth, 0L))
-                            currentMonth++
+                            if (currentMonth+1 > 12) currentMonth = 1 else currentMonth++
                         }
-                        currentMonth++
+                        if (currentMonth+1 > 12) currentMonth = 1 else currentMonth++
                         add(Pair(month, amount))
                     }
                 }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSourceImpl.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSourceImpl.kt
@@ -161,13 +161,19 @@ class AccountBookDataSourceImpl @Inject constructor(
             var total = 0L
             val res = mutableListOf<Pair<Int, Long>>().apply {
                 with(cursor) {
+                    var currentMonth = startMonth
                     while (moveToNext()) {
                         val date = getString(getColumnIndexOrThrow(HistoryColumns.COLUMN_NAME_DATE))
                         val amount = getLong(getColumnIndexOrThrow("total_amount"))
                         total += amount
 
-                        val month = date.split("-")[1] // 2000-01 --> "01"
-                        add(Pair(month.toInt(), amount))
+                        val month = date.split("-")[1].toInt() // 2000-09 --> 9
+                        while (month > currentMonth) { // 7~12월까지인데 10, 12월만 데이터가 있다면 7,8,9,11 월에는 0 넣기
+                            add(Pair(currentMonth, 0L))
+                            currentMonth++
+                        }
+                        currentMonth++
+                        add(Pair(month, amount))
                     }
                 }
                 cursor.close()

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSourceImpl.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSourceImpl.kt
@@ -84,17 +84,54 @@ class AccountBookDataSourceImpl @Inject constructor(
                         val categoryType = getInt(getColumnIndexOrThrow("category_type"))
                         val categoryName = getString(getColumnIndexOrThrow("category_name"))
                         val categoryColor = getLong(getColumnIndexOrThrow("category_color"))
+
                         val history = History(
                             id, type, content, date, amount,
                             if (type == 1) null else PaymentMethod(paymentId, paymentName),
                             Category(categoryId, categoryType, categoryName, categoryColor)
                         )
+
                         val monthDay = history.date.substring(5)
                         if (containsKey(monthDay)) {
                             get(monthDay)?.add(history)
                         } else {
                             put(monthDay, mutableListOf(history))
                         }
+                    }
+                }
+                cursor.close()
+            }
+        }
+
+    override fun readHistoriesEachCategory(
+        year: Int,
+        month: Int,
+        categoryId: Long
+    ): List<History>
+        = readableDB.run {
+            val cursor = rawQuery(SQL_SELECT_CATEGORY_HISTORIES, arrayOf(getMonthAndYearHyphen(year, month), categoryId.toString()))
+
+            mutableListOf<History>().apply {
+                with(cursor) {
+                    while (moveToNext()) {
+                        val id = getLong(getColumnIndexOrThrow(BaseColumns._ID))
+                        val type = getInt(getColumnIndexOrThrow(HistoryColumns.COLUMN_NAME_TYPE))
+                        val content = getString(getColumnIndexOrThrow(HistoryColumns.COLUMN_NAME_CONTENT))
+                        val date = getString(getColumnIndexOrThrow(HistoryColumns.COLUMN_NAME_DATE))
+                        val amount = getInt(getColumnIndexOrThrow(HistoryColumns.COLUMN_NAME_AMOUNT))
+                        val paymentId = getLong(getColumnIndexOrThrow("payment_id"))
+                        val paymentName = getString(getColumnIndexOrThrow("payment_name"))
+                        val categoryType = getInt(getColumnIndexOrThrow("category_type"))
+                        val categoryName = getString(getColumnIndexOrThrow("category_name"))
+                        val categoryColor = getLong(getColumnIndexOrThrow("category_color"))
+
+                        val history = History(
+                            id, type, content, date, amount,
+                            if (type == 1) null else PaymentMethod(paymentId, paymentName),
+                            Category(categoryId, categoryType, categoryName, categoryColor)
+                        )
+
+                        add(history)
                     }
                 }
                 cursor.close()

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSourceImpl.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSourceImpl.kt
@@ -150,7 +150,7 @@ class AccountBookDataSourceImpl @Inject constructor(
         endYear: Int,
         endMonth: Int,
         categoryId: Long
-    ): List<Pair<Int, Int>>
+    ): List<Pair<Int, Long>>
         = readableDB.run {
             val cursor = rawQuery(SQL_SUM_MONTHLY_AMOUNTS, arrayOf(
                 getMonthAndYearHyphen(startYear, startMonth),
@@ -158,14 +158,12 @@ class AccountBookDataSourceImpl @Inject constructor(
                 categoryId.toString())
             )
 
-            var total = 0L
-            val res = mutableListOf<Pair<Int, Long>>().apply {
+            mutableListOf<Pair<Int, Long>>().apply {
                 with(cursor) {
                     var currentMonth = startMonth
                     while (moveToNext()) {
                         val date = getString(getColumnIndexOrThrow(HistoryColumns.COLUMN_NAME_DATE))
                         val amount = getLong(getColumnIndexOrThrow("total_amount"))
-                        total += amount
 
                         val month = date.split("-")[1].toInt() // 2000-09 --> 9
                         while (month > currentMonth) { // 7~12월까지인데 10, 12월만 데이터가 있다면 7,8,9,11 월에는 0 넣기
@@ -178,10 +176,6 @@ class AccountBookDataSourceImpl @Inject constructor(
                 }
                 cursor.close()
             }
-
-            res.map {
-                Pair(it.first, (round(it.second.toDouble()/total*100)).toInt())
-            } // 백분율
         }
 
     override fun readAllPaymentMethod(): List<PaymentMethod>

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSourceImpl.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookDataSourceImpl.kt
@@ -107,11 +107,11 @@ class AccountBookDataSourceImpl @Inject constructor(
         year: Int,
         month: Int,
         categoryId: Long
-    ): List<History>
+    ): Map<String, List<History>>
         = readableDB.run {
             val cursor = rawQuery(SQL_SELECT_CATEGORY_HISTORIES, arrayOf(getMonthAndYearHyphen(year, month), categoryId.toString()))
 
-            mutableListOf<History>().apply {
+            mutableMapOf<String, MutableList<History>>().apply {
                 with(cursor) {
                     while (moveToNext()) {
                         val id = getLong(getColumnIndexOrThrow(BaseColumns._ID))
@@ -131,7 +131,12 @@ class AccountBookDataSourceImpl @Inject constructor(
                             Category(categoryId, categoryType, categoryName, categoryColor)
                         )
 
-                        add(history)
+                        val monthDay = history.date.substring(5)
+                        if (containsKey(monthDay)) {
+                            get(monthDay)?.add(history)
+                        } else {
+                            put(monthDay, mutableListOf(history))
+                        }
                     }
                 }
                 cursor.close()

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
@@ -12,7 +12,7 @@ class AccountBookRepository @Inject constructor(
     fun readMonthlyHistories(year: Int, month: Int): Result<Map<String, List<History>>>
         = runCatching { dataSource.readMonthlyHistories(year, month) }
 
-    fun readHistoriesEachCategory(year: Int, month: Int, categoryId: Long): Result<List<History>>
+    fun readHistoriesEachCategory(year: Int, month: Int, categoryId: Long): Result<Map<String, List<History>>>
         = runCatching { dataSource.readHistoriesEachCategory(year, month, categoryId) }
 
     fun readAllPaymentMethod(): Result<List<PaymentMethod>>

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
@@ -21,7 +21,7 @@ class AccountBookRepository @Inject constructor(
         endYear: Int,
         endMonth: Int,
         categoryId: Long
-    ): Result<List<Pair<Int, Int>>>
+    ): Result<List<Pair<Int, Long>>>
         = runCatching { dataSource.readMonthlyTotalAmount(startYear, startMonth, endYear, endMonth, categoryId) }
 
     fun readAllPaymentMethod(): Result<List<PaymentMethod>>

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
@@ -15,6 +15,15 @@ class AccountBookRepository @Inject constructor(
     fun readHistoriesEachCategory(year: Int, month: Int, categoryId: Long): Result<Map<String, List<History>>>
         = runCatching { dataSource.readHistoriesEachCategory(year, month, categoryId) }
 
+    fun readMonthlyTotalAmount(
+        startYear: Int,
+        startMonth: Int,
+        endYear: Int,
+        endMonth: Int,
+        categoryId: Long
+    ): Result<List<Pair<Int, Int>>>
+        = runCatching { dataSource.readMonthlyTotalAmount(startYear, startMonth, endYear, endMonth, categoryId) }
+
     fun readAllPaymentMethod(): Result<List<PaymentMethod>>
         = runCatching { dataSource.readAllPaymentMethod() }
 

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/AccountBookRepository.kt
@@ -12,14 +12,17 @@ class AccountBookRepository @Inject constructor(
     fun readMonthlyHistories(year: Int, month: Int): Result<Map<String, List<History>>>
         = runCatching { dataSource.readMonthlyHistories(year, month) }
 
+    fun readHistoriesEachCategory(year: Int, month: Int, categoryId: Long): Result<List<History>>
+        = runCatching { dataSource.readHistoriesEachCategory(year, month, categoryId) }
+
     fun readAllPaymentMethod(): Result<List<PaymentMethod>>
         = runCatching { dataSource.readAllPaymentMethod() }
 
     fun readAllExpensesCategory(): Result<List<Category>>
-            = runCatching { dataSource.readAllExpensesCategory() }
+        = runCatching { dataSource.readAllExpensesCategory() }
 
     fun readAllIncomeCategory(): Result<List<Category>>
-            = runCatching { dataSource.readAllIncomeCategory() }
+        = runCatching { dataSource.readAllIncomeCategory() }
 
     fun insertHistory(
         type: Int,
@@ -29,7 +32,7 @@ class AccountBookRepository @Inject constructor(
         paymentId: Long? = null,
         categoryId: Long
     ): Result<Long>
-            = runCatching { dataSource.createHistory(type, content, date, amount, paymentId, categoryId) }
+        = runCatching { dataSource.createHistory(type, content, date, amount, paymentId, categoryId) }
 
     fun createPaymentMethod(name: String): Result<Long>
         = runCatching { dataSource.createPaymentMethod(name) }
@@ -46,14 +49,14 @@ class AccountBookRepository @Inject constructor(
         paymentMethod: PaymentMethod? = null,
         category: Category? = null
     ): Result<Int>
-            = runCatching { dataSource.updateHistory(id, type, content, amount, date, paymentMethod, category) }
+        = runCatching { dataSource.updateHistory(id, type, content, amount, date, paymentMethod, category) }
 
     fun updatePaymentMethod(id: Long, name: String): Result<Int>
-            = runCatching { dataSource.updatePaymentMethod(id, name) }
+        = runCatching { dataSource.updatePaymentMethod(id, name) }
 
     fun updateCategory(id: Long, name: String, color: Long): Result<Int>
-            = runCatching { dataSource.updateCategory(id, name, color) }
+        = runCatching { dataSource.updateCategory(id, name, color) }
 
     fun deleteHistories(ids: List<Long>)
-            = runCatching { dataSource.deleteHistories(ids) }
+        = runCatching { dataSource.deleteHistories(ids) }
 }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/utils/SQLConfig.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/utils/SQLConfig.kt
@@ -84,7 +84,7 @@ const val SQL_INSERT_INCOME_CATEGORY_3 = "INSERT INTO ${CategoryColumns.TABLE_NA
 /**
  * Select Rows
  */
-const val SQL_SELECT_ALL_HISTORY =
+const val SQL_SELECT_MONTHLY_HISTORIES =
     "SELECT " +
             "${HistoryColumns.TABLE_NAME}.${BaseColumns._ID}," +
             "${HistoryColumns.TABLE_NAME}.${HistoryColumns.COLUMN_NAME_TYPE}," +
@@ -126,4 +126,14 @@ const val SQL_SELECT_CATEGORY_HISTORIES =
     " LEFT JOIN ${CategoryColumns.TABLE_NAME}" +
             " ON ${HistoryColumns.TABLE_NAME}.${HistoryColumns.COLUMN_NAME_CATEGORY_ID} = ${CategoryColumns.TABLE_NAME}.${BaseColumns._ID}" +
     " WHERE substr(${HistoryColumns.COLUMN_NAME_DATE}, 1, 7) = ? AND ${HistoryColumns.COLUMN_NAME_CATEGORY_ID} = ?" + // 2001-01-30 이면 2001-01 까지 가져온다.
+    " ORDER BY ${HistoryColumns.COLUMN_NAME_DATE} ASC"
+
+const val SQL_SUM_MONTHLY_AMOUNTS =
+    "SELECT " +
+            "sum(${HistoryColumns.COLUMN_NAME_AMOUNT}) total_amount," +
+            HistoryColumns.COLUMN_NAME_DATE +
+    " FROM ${HistoryColumns.TABLE_NAME}" +
+    " WHERE substr(${HistoryColumns.COLUMN_NAME_DATE}, 1, 7) BETWEEN ? AND ?" +
+    " AND ${HistoryColumns.COLUMN_NAME_CATEGORY_ID} = ?" +
+    " GROUP BY substr(${HistoryColumns.COLUMN_NAME_DATE}, 1, 7)" +
     " ORDER BY ${HistoryColumns.COLUMN_NAME_DATE} ASC"

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/data/utils/SQLConfig.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/data/utils/SQLConfig.kt
@@ -104,3 +104,26 @@ const val SQL_SELECT_ALL_HISTORY =
             " ON ${HistoryColumns.TABLE_NAME}.${HistoryColumns.COLUMN_NAME_CATEGORY_ID} = ${CategoryColumns.TABLE_NAME}.${BaseColumns._ID}" +
     " WHERE substr(${HistoryColumns.COLUMN_NAME_DATE}, 1, 7) = ?" + // 2001-01-30 이면 2001-01 까지 가져온다.
     " ORDER BY ${HistoryColumns.COLUMN_NAME_DATE} ASC"
+
+/**
+ * Select Rows
+ */
+const val SQL_SELECT_CATEGORY_HISTORIES =
+    "SELECT " +
+            "${HistoryColumns.TABLE_NAME}.${BaseColumns._ID}," +
+            "${HistoryColumns.TABLE_NAME}.${HistoryColumns.COLUMN_NAME_TYPE}," +
+            "${HistoryColumns.COLUMN_NAME_CONTENT}," +
+            "${HistoryColumns.COLUMN_NAME_DATE}," +
+            "${HistoryColumns.COLUMN_NAME_AMOUNT}," +
+            "${PaymentMethodColumns.TABLE_NAME}.${BaseColumns._ID} payment_id," +
+            "${PaymentMethodColumns.TABLE_NAME}.${PaymentMethodColumns.COLUMN_NAME_NAME} payment_name," +
+            "${CategoryColumns.TABLE_NAME}.${CategoryColumns.COLUMN_NAME_TYPE} category_type," +
+            "${CategoryColumns.TABLE_NAME}.${CategoryColumns.COLUMN_NAME_NAME} category_name," +
+            "${CategoryColumns.COLUMN_NAME_COLOR} category_color" +
+    " FROM ${HistoryColumns.TABLE_NAME}" +
+    " LEFT JOIN ${PaymentMethodColumns.TABLE_NAME}" +
+            " ON ${HistoryColumns.TABLE_NAME}.${HistoryColumns.COLUMN_NAME_PAYMENT_ID} = ${PaymentMethodColumns.TABLE_NAME}.${BaseColumns._ID}" +
+    " LEFT JOIN ${CategoryColumns.TABLE_NAME}" +
+            " ON ${HistoryColumns.TABLE_NAME}.${HistoryColumns.COLUMN_NAME_CATEGORY_ID} = ${CategoryColumns.TABLE_NAME}.${BaseColumns._ID}" +
+    " WHERE substr(${HistoryColumns.COLUMN_NAME_DATE}, 1, 7) = ? AND ${HistoryColumns.COLUMN_NAME_CATEGORY_ID} = ?" + // 2001-01-30 이면 2001-01 까지 가져온다.
+    " ORDER BY ${HistoryColumns.COLUMN_NAME_DATE} ASC"

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/components/HistoryView.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/components/HistoryView.kt
@@ -1,24 +1,19 @@
-package com.woowacamp.android_accountbook_15.ui.tabs.history
+package com.woowacamp.android_accountbook_15.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Divider
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.woowacamp.android_accountbook_15.data.model.History
-import com.woowacamp.android_accountbook_15.ui.components.CategoryView
-import com.woowacamp.android_accountbook_15.ui.components.CheckableItem
 import com.woowacamp.android_accountbook_15.ui.theme.*
 import com.woowacamp.android_accountbook_15.utils.toMoneyString
+
 
 @Composable
 fun HistoryCard(
@@ -40,7 +35,8 @@ fun HistoryCard(
             Text(modifier = Modifier.weight(1f), text = date, color = LightPurple)
             Text(text = "수입  ${list.sumOf { if (it.type == 1) it.amount else 0}.toMoneyString()}" +
                     "  지출  ${(list.sumOf { if (it.type == 0) it.amount else 0 }*-1).toMoneyString()}",
-                fontSize = 10.sp, color = LightPurple)
+                fontSize = 10.sp, color = LightPurple
+            )
         }
 
         Column {
@@ -55,7 +51,7 @@ fun HistoryCard(
                         onLongPress = { onLongPress(history.id) },
                         onUpdateClick = { onUpdateClick(history) }
                     ) {
-                        HistoryItem(history)
+                        HistoryItem(history = history)
                     }
                 }
             }
@@ -66,10 +62,39 @@ fun HistoryCard(
 }
 
 @Composable
-private fun HistoryItem(
-    history: History
+fun HistoryCard(
+    modifier: Modifier = Modifier,
+    date: String,
+    list: List<History>
 ) {
     Column {
+        Row(
+            modifier = modifier.padding(16.dp, 8.dp),
+            verticalAlignment = Alignment.Bottom
+        ) {
+            Text(modifier = Modifier.weight(1f), text = date, color = LightPurple)
+            Text(text = "지출  ${(list.sumOf { if (it.type == 0) it.amount else 0 }*-1).toMoneyString()}",
+                fontSize = 10.sp, color = LightPurple)
+        }
+
+        Column {
+            list.forEach { history ->
+                Divider(color = Purple04, thickness = 1.dp, modifier = Modifier.padding(16.dp, 0.dp))
+                HistoryItem(history = history)
+            }
+        }
+    }
+    Divider(color = LightPurple, thickness = 1.dp)
+    Spacer(modifier = Modifier.size(16.dp))
+}
+
+@Composable
+private fun HistoryItem(
+    modifier: Modifier = Modifier,
+    history: History
+) {
+    Column(modifier = modifier
+        .padding(16.dp, 8.dp)) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             CategoryView(color = history.category.color, name = history.category.name)
             Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/components/Item.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/components/Item.kt
@@ -14,12 +14,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.woowacamp.android_accountbook_15.R
+import com.woowacamp.android_accountbook_15.data.model.History
 import com.woowacamp.android_accountbook_15.ui.theme.*
 import com.woowacamp.android_accountbook_15.utils.getDayKorean
 import com.woowacamp.android_accountbook_15.utils.toMoneyInt
@@ -268,7 +270,6 @@ fun CheckableItem(
     Row(
         modifier = modifier
             .background(if (isChecked) White else OffWhite)
-            .padding(16.dp, 8.dp)
             .combinedClickable(
                 onClick = {
                     if (isSelectMode) {

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/DetailScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/DetailScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -22,7 +23,7 @@ import com.woowacamp.android_accountbook_15.utils.getDayKoreanWithoutYear
 @Composable
 fun DetailScreen(
     year: Int,
-    amounts: List<Pair<Int, Int>>,
+    amounts: List<Pair<Int, Long>>,
     histories: Map<String, List<History>>,
     onBackClick: () -> Unit
 ) {
@@ -40,7 +41,7 @@ fun DetailScreen(
         }
 
         Column() {
-            ChartCard(amounts = amounts, modifier = Modifier.background(White))
+            ChartCard(amounts = amounts, modifier = Modifier.background(White).fillMaxWidth())
 
             LazyColumn {
                 item {

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/DetailScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/DetailScreen.kt
@@ -1,18 +1,26 @@
 package com.woowacamp.android_accountbook_15.ui.tabs.graph
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
 import com.woowacamp.android_accountbook_15.R
 import com.woowacamp.android_accountbook_15.data.model.History
 import com.woowacamp.android_accountbook_15.ui.components.Header
+import com.woowacamp.android_accountbook_15.ui.components.HistoryCard
+import com.woowacamp.android_accountbook_15.utils.getDayKoreanWithoutYear
 
 @Composable
 fun DetailScreen(
-    histories: List<History>,
+    year: Int,
+    histories: Map<String, List<History>>,
     onBackClick: () -> Unit
 ) {
     Scaffold(
@@ -28,6 +36,26 @@ fun DetailScreen(
             onBackClick()
         }
 
-        Text(text = histories.toString())
+        Column() {
+            ChartCard()
+
+            LazyColumn {
+                item {
+                    histories.forEach { (key, value) ->
+                        val splitDate = key.split("-").map { it.toInt() }
+                        HistoryCard(
+                            date = getDayKoreanWithoutYear(year, splitDate[0], splitDate[1]),
+                            list = value)
+                    }
+                }
+            }
+        }
     }
+}
+
+@Composable
+fun ChartCard(
+    modifier: Modifier = Modifier
+) {
+
 }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/DetailScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/DetailScreen.kt
@@ -1,0 +1,33 @@
+package com.woowacamp.android_accountbook_15.ui.tabs.graph
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.res.painterResource
+import com.woowacamp.android_accountbook_15.R
+import com.woowacamp.android_accountbook_15.data.model.History
+import com.woowacamp.android_accountbook_15.ui.components.Header
+
+@Composable
+fun DetailScreen(
+    histories: List<History>,
+    onBackClick: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            Header(
+                title = "상세 내역 보기",
+                leftIcon = painterResource(R.drawable.ic_back),
+                onLeftClick = onBackClick
+            )
+        }
+    ) {
+        BackHandler {
+            onBackClick()
+        }
+
+        Text(text = histories.toString())
+    }
+}

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/DetailScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/DetailScreen.kt
@@ -1,6 +1,7 @@
 package com.woowacamp.android_accountbook_15.ui.tabs.graph
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
@@ -15,11 +16,13 @@ import com.woowacamp.android_accountbook_15.R
 import com.woowacamp.android_accountbook_15.data.model.History
 import com.woowacamp.android_accountbook_15.ui.components.Header
 import com.woowacamp.android_accountbook_15.ui.components.HistoryCard
+import com.woowacamp.android_accountbook_15.ui.theme.White
 import com.woowacamp.android_accountbook_15.utils.getDayKoreanWithoutYear
 
 @Composable
 fun DetailScreen(
     year: Int,
+    amounts: List<Pair<Int, Int>>,
     histories: Map<String, List<History>>,
     onBackClick: () -> Unit
 ) {
@@ -37,7 +40,7 @@ fun DetailScreen(
         }
 
         Column() {
-            ChartCard()
+            ChartCard(amounts = amounts, modifier = Modifier.background(White))
 
             LazyColumn {
                 item {
@@ -51,11 +54,4 @@ fun DetailScreen(
             }
         }
     }
-}
-
-@Composable
-fun ChartCard(
-    modifier: Modifier = Modifier
-) {
-
 }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphCard.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphCard.kt
@@ -2,6 +2,7 @@ package com.woowacamp.android_accountbook_15.ui.tabs.graph
 
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
@@ -29,12 +30,13 @@ import kotlin.math.round
 
 @Composable
 fun AnimatedGraphCard(
+    graphState: Boolean,
     proportions: List<Float>,
     colors: List<Color>,
     modifier: Modifier = Modifier
 ) {
     var animateFloat = remember { Animatable(0f) }
-    LaunchedEffect(animateFloat, proportions) {
+    LaunchedEffect(animateFloat, graphState) {
         animateFloat = Animatable(0f)
         animateFloat.animateTo(
             targetValue = 1f,
@@ -70,14 +72,19 @@ fun AnimatedGraphCard(
 @Composable
 fun ExpensesCard(
     expenses: Map<Category, Float>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onClick: (Long) -> Unit
 ) {
     val totalExpenses = expenses.values.sum()
     LazyColumn(modifier = modifier) {
         item {
             expenses.forEach { (key, value) ->
                 Row(
-                    modifier = Modifier.padding(0.dp, 8.dp),
+                    modifier = Modifier
+                        .padding(0.dp, 8.dp)
+                        .clickable {
+                            onClick(key.id)
+                        },
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     CategoryView(color = key.color, name = key.name)

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphCard.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphCard.kt
@@ -3,12 +3,10 @@ package com.woowacamp.android_accountbook_15.ui.tabs.graph
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Divider
+import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -20,11 +18,13 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.woowacamp.android_accountbook_15.data.model.Category
 import com.woowacamp.android_accountbook_15.ui.components.CategoryView
 import com.woowacamp.android_accountbook_15.ui.theme.LightPurple
+import com.woowacamp.android_accountbook_15.ui.theme.Purple
 import com.woowacamp.android_accountbook_15.utils.toMoneyString
 import kotlin.math.round
 
@@ -97,4 +97,42 @@ fun ExpensesCard(
             }
         }
     }
+}
+
+@Composable
+fun ChartCard(
+    amounts: List<Pair<Int, Int>>,
+    modifier: Modifier = Modifier
+) {
+    Canvas(modifier = modifier
+        .fillMaxWidth()
+        .height(200.dp)
+        .padding(24.dp, 16.dp)
+    ) {
+        val height = size.height
+        val width = size.width
+        var x = 0f
+        var prev = amounts[0]
+        for (i in 1 until amounts.size) {
+            drawLine(
+                start = Offset(x = x, y = height - height/100*prev.second),
+                end = Offset(x = x + width/(amounts.size-1), y = height - height/100*amounts[i].second),
+                color = Purple,
+                strokeWidth = 3.0f
+            )
+            x += width/(amounts.size-1)
+            prev = amounts[i]
+        }
+    }
+
+    Row(
+        modifier = modifier.fillMaxWidth().padding(24.dp, 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        for (e in amounts) {
+            Text(text = "${e.first}", textAlign = TextAlign.Center, fontSize = 14.sp)
+        }
+    }
+
+    Divider(color = Purple, thickness = 1.dp)
 }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphFragment.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphFragment.kt
@@ -17,7 +17,8 @@ class GraphFragment : Fragment() {
     private var _binding: FragmentGraphBinding? = null
     private val binding: FragmentGraphBinding get() = requireNotNull(_binding)
 
-    private val viewModel: HistoryViewModel by activityViewModels()
+    private val historyViewModel: HistoryViewModel by activityViewModels()
+    private val graphViewModel: GraphViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -31,7 +32,7 @@ class GraphFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         binding.composeGraph.setContent {
             AndroidAccountBook15Theme {
-                GraphScreen(viewModel) {
+                GraphScreen(historyViewModel, graphViewModel) {
                     (activity as MainActivity).backToMain()
                 }
             }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphScreen.kt
@@ -50,6 +50,7 @@ fun GraphScreen(
                 setScreenState(ScreenType.DETAIL_GRAPH)
             })
         ScreenType.DETAIL_GRAPH -> DetailScreen(
+            year,
             graphViewModel.historiesEachCategory.collectAsState().value,
             onBackClick = {
                 setCircleGraphState(!circleGraphState)

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphScreen.kt
@@ -51,6 +51,7 @@ fun GraphScreen(
             })
         ScreenType.DETAIL_GRAPH -> DetailScreen(
             year,
+            graphViewModel.monthlyTotalAmountEachCategory.collectAsState().value,
             graphViewModel.historiesEachCategory.collectAsState().value,
             onBackClick = {
                 setCircleGraphState(!circleGraphState)
@@ -75,9 +76,10 @@ private fun GraphScreen(
         viewModel.monthlyHistories.value.forEach { (_, value) ->
             value.forEach { history ->
                 if (history.type != 1)
-                    if (temp.containsKey(history.category))
-                        temp[history.category]?.plus(history.amount)
-                    else
+                    if (temp.containsKey(history.category) && temp[history.category] != null) {
+                        val amount = temp[history.category]!!.toFloat()
+                        temp[history.category] = amount + history.amount.toFloat()
+                    } else
                         temp[history.category] = history.amount.toFloat()
             }
         }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphViewModel.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphViewModel.kt
@@ -16,7 +16,13 @@ class GraphViewModel @Inject constructor(
     private val _historiesEachCategory = MutableStateFlow(mapOf<String, List<History>>())
     val historiesEachCategory: StateFlow<Map<String, List<History>>> get() = _historiesEachCategory
 
+    private val _monthlyTotalAmountEachCategory = MutableStateFlow(listOf<Pair<Int, Int>>())
+    val monthlyTotalAmountEachCategory: StateFlow<List<Pair<Int, Int>>> get() = _monthlyTotalAmountEachCategory
+
     fun setHistories(year: Int, month: Int, categoryId: Long) {
+        val startYear = if (month-5 > 0) year else year-1
+        val startMonth = if (month-5 > 0) month-5 else month+12-5
         _historiesEachCategory.value = repository.readHistoriesEachCategory(year, month, categoryId).getOrThrow()
+        _monthlyTotalAmountEachCategory.value = repository.readMonthlyTotalAmount(startYear, startMonth, year, month, categoryId).getOrThrow()
     }
 }

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphViewModel.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphViewModel.kt
@@ -1,0 +1,23 @@
+package com.woowacamp.android_accountbook_15.ui.tabs.graph
+
+import androidx.lifecycle.ViewModel
+import com.woowacamp.android_accountbook_15.data.AccountBookRepository
+import com.woowacamp.android_accountbook_15.data.model.Category
+import com.woowacamp.android_accountbook_15.data.model.History
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class GraphViewModel @Inject constructor(
+    private val repository: AccountBookRepository
+): ViewModel() {
+
+    private val _historiesEachCategory = MutableStateFlow(listOf<History>())
+    val historiesEachCategory: StateFlow<List<History>> get() = _historiesEachCategory
+
+    fun setHistories(year: Int, month: Int, categoryId: Long) {
+        _historiesEachCategory.value = repository.readHistoriesEachCategory(year, month, categoryId).getOrThrow()
+    }
+}

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphViewModel.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphViewModel.kt
@@ -16,8 +16,8 @@ class GraphViewModel @Inject constructor(
     private val _historiesEachCategory = MutableStateFlow(mapOf<String, List<History>>())
     val historiesEachCategory: StateFlow<Map<String, List<History>>> get() = _historiesEachCategory
 
-    private val _monthlyTotalAmountEachCategory = MutableStateFlow(listOf<Pair<Int, Int>>())
-    val monthlyTotalAmountEachCategory: StateFlow<List<Pair<Int, Int>>> get() = _monthlyTotalAmountEachCategory
+    private val _monthlyTotalAmountEachCategory = MutableStateFlow(listOf<Pair<Int, Long>>())
+    val monthlyTotalAmountEachCategory: StateFlow<List<Pair<Int, Long>>> get() = _monthlyTotalAmountEachCategory
 
     fun setHistories(year: Int, month: Int, categoryId: Long) {
         val startYear = if (month-5 > 0) year else year-1

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphViewModel.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/graph/GraphViewModel.kt
@@ -2,7 +2,6 @@ package com.woowacamp.android_accountbook_15.ui.tabs.graph
 
 import androidx.lifecycle.ViewModel
 import com.woowacamp.android_accountbook_15.data.AccountBookRepository
-import com.woowacamp.android_accountbook_15.data.model.Category
 import com.woowacamp.android_accountbook_15.data.model.History
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,8 +13,8 @@ class GraphViewModel @Inject constructor(
     private val repository: AccountBookRepository
 ): ViewModel() {
 
-    private val _historiesEachCategory = MutableStateFlow(listOf<History>())
-    val historiesEachCategory: StateFlow<List<History>> get() = _historiesEachCategory
+    private val _historiesEachCategory = MutableStateFlow(mapOf<String, List<History>>())
+    val historiesEachCategory: StateFlow<Map<String, List<History>>> get() = _historiesEachCategory
 
     fun setHistories(year: Int, month: Int, categoryId: Long) {
         _historiesEachCategory.value = repository.readHistoriesEachCategory(year, month, categoryId).getOrThrow()

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/HistoryScreen.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/tabs/history/HistoryScreen.kt
@@ -19,10 +19,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.woowacamp.android_accountbook_15.R
 import com.woowacamp.android_accountbook_15.data.model.History
-import com.woowacamp.android_accountbook_15.ui.components.DatePicker
-import com.woowacamp.android_accountbook_15.ui.components.FloatingButton
-import com.woowacamp.android_accountbook_15.ui.components.Header
-import com.woowacamp.android_accountbook_15.ui.components.PurpleCheckBox
+import com.woowacamp.android_accountbook_15.ui.components.*
 import com.woowacamp.android_accountbook_15.ui.tabs.setting.SettingViewModel
 import com.woowacamp.android_accountbook_15.ui.theme.Grey1
 import com.woowacamp.android_accountbook_15.ui.theme.LightPurple

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/ui/theme/Color.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/ui/theme/Color.kt
@@ -7,6 +7,7 @@ val Purple500 = Color(0xFF6200EE)
 val Purple700 = Color(0xFF3700B3)
 val Teal200 = Color(0xFF03DAC5)
 
+val PurpleLong = 0xFF524D90
 val Purple = Color(0xFF524D90)
 val LightPurple = Color(0xFFA79FCB)
 val Purple04 = Color(0x66A79FCB)

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/utils/MoneyUtil.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/utils/MoneyUtil.kt
@@ -6,3 +6,5 @@ import java.text.DecimalFormat
 fun Int.toMoneyString(): String = DecimalFormat("#,###").format(this)
 
 fun String.toMoneyInt(): Int = this.replace(",","").toInt()
+
+fun Long.toMoneyString(): String = DecimalFormat("#,###").format(this)

--- a/app/src/main/java/com/woowacamp/android_accountbook_15/utils/OffsetUtil.kt
+++ b/app/src/main/java/com/woowacamp/android_accountbook_15/utils/OffsetUtil.kt
@@ -1,0 +1,11 @@
+package com.woowacamp.android_accountbook_15.utils
+
+import android.graphics.Rect
+import androidx.compose.ui.graphics.NativePaint
+
+fun getRect(paint: NativePaint, text: String): Pair<Int, Int> {
+    val rect = Rect() // text 의 크기
+    paint.getTextBounds(text, 0, text.length, rect)
+
+    return Pair(rect.width(), rect.height())
+}


### PR DESCRIPTION
## 직선 그래프
최근 개월 수는 요구 사항과 일치하게 6개월로 정하였다.
drawLine을 공부한 뒤 점 두개만 주어지면 직선을 쉽게 그릴 수 있다는 것을 알았다.
그래서 첫 점을 먼저 저장해 둔 뒤, (리스트 길이) - 1 만큼 반복문을 돌려 이전 점과 현재 점을 잇는 그래프를 만들었다.

위 부분은 단순해서 쉬웠는데, 문제는 Canvas 위에 텍스트 띄우기였다.
영어를 그닥 잘하지 못해서 NativePaint에서 Text 컴포넌트의 크기를 재는 방법을 한참동안 찾았다.
결국 찾아서 `OffsetUtil.kt` 파일에 아래와 같이 정의했다.

``` Kotlin
fun getRect(paint: NativePaint, text: String): Pair<Int, Int> {
    val rect = Rect() // text 의 크기
    paint.getTextBounds(text, 0, text.length, rect)

    return Pair(rect.width(), rect.height())
}
```

크기의 ÷2를 x좌표에서 빼서 Offset을 조절해 줬다.
하지만 기능 자체는 top과 left의 Offset만 지정할 수 있다.
점 위치와 텍스트의 위치가 동일한 것이 예쁘기 때문에,

<img width="345" alt="image" src="https://user-images.githubusercontent.com/47631768/182820770-afac329a-a723-47bc-aae1-dc1942ab51e9.png">

위의 빨간 선이 Row에 Text들의 `weight`를 `1f`로 준것이고,

<img width="344" alt="image" src="https://user-images.githubusercontent.com/47631768/182821560-76803025-4844-4477-a8a7-006c6747030e.png">

점선을 보면 처음 결정한 (리스트 길이)에 2를 곱하여 12개로 쪼갠 뒤, 홀수 번째 마다 점을 찍어 그래프를 완성하였다.